### PR TITLE
Update faraday to 1.0 to match hyrax 4.0 requirements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     handle_rest (0.0.4)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.14.0)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,12 +13,33 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.7.6)
-    faraday (0.17.5)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.14.0)
-      faraday (>= 0.7.4, < 1.0)
+    faraday (1.10.3)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
     method_source (1.0.0)
-    multipart-post (2.1.1)
+    multipart-post (2.3.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -61,6 +82,7 @@ GEM
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -77,6 +99,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/handle_rest.gemspec
+++ b/handle_rest.gemspec
@@ -14,16 +14,9 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   s.homepage = "https://github.com/mlibrary/handle_rest"
   s.license = "APACHE2"
-  # Bundler could not find compatible versions for gem "faraday":
-  #   In Gemfile:
-  #     faraday (~> 2)
-  #
-  #     hyrax (= 2.9.5) was resolved to 2.9.5, which depends on
-  #       signet was resolved to 0.12.0, which depends on
-  #         faraday (~> 0.9)
-  s.add_dependency "faraday", "~> 0.9"
-  # NOTE: This is the last minor release in the v0.x series, next release will be 1.0 to match Faraday v1.0 release and from then on only fixes will be applied to v0.14.x!
-  s.add_dependency "faraday_middleware", "~> 0.14.0"
+
+  s.add_dependency "faraday", "~> 1.0"
+  s.add_dependency "faraday_middleware", "~> 1.0"
   s.required_ruby_version = ">= 2.6"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
Since Hyrax 4 no longer needs the really old 0.9 Faraday I've updated to a (slightly) newer one that Hyrax 4 does need.

When this is merged could we get a 0.0.5 release for it?